### PR TITLE
Renice ModemManager too

### DIFF
--- a/phosh_renice.sh
+++ b/phosh_renice.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-PIDS = "$(pidof phoc) $(pidof phosh) $(pidof squeekboard) $(pidof calls)"
+PIDS = "$(pidof phoc) $(pidof phosh) $(pidof squeekboard) $(pidof calls) $(pidof ModemManager)"
 renice -n -1 -p $PIDS
 


### PR DESCRIPTION
I tried this script on my PinePhone running Mobian.
Phosh, Phoc, etc. are much faster ready after a deep sleep, but the phone didn't ring.
From the Phosh lockscreen I saw that the mobile indicator was still missing, so ModemManager wasn't up yet.

Adding ModemManager to the list of PIDs seems to improve this situation, After 3-5 rings (caller side), the phone starts to ring too.