### PR TITLE
Correcting script mistakes and waiting for processes

### DIFF
--- a/phosh-renice.service
+++ b/phosh-renice.service
@@ -6,7 +6,7 @@ Requires=phosh.service
 [Service]
 TimeoutStartSec=0
 Restart=on-failure
-ExecStart=/usr/bin/bash /usr/local/sbin/phosh_renice
+ExecStart=/bin/sh /usr/local/sbin/phosh_renice
 
 [Install]
 WantedBy=multi-user.target

--- a/phosh_renice.sh
+++ b/phosh_renice.sh
@@ -1,5 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
-PIDS = "$(pidof phoc) $(pidof phosh) $(pidof squeekboard) $(pidof calls) $(pidof ModemManager)"
+until PIDS="$(pidof phoc) $(pidof phosh) $(pidof squeekboard) $(pidof calls) $(pidof ModemManager)"
+do
+	sleep 1
+done
+
 renice -n -1 -p $PIDS
-


### PR DESCRIPTION
This pull request fixes a simple scripting mistake, as well as adding a check to make sure all the processes has started.

The mistake here is variables doesn't have a space between the name and the value, so this is how it is supposed to be: `PIDS="$(pidof ...)"`

In your script, this is how you did it `PIDS = "$(pidof ...)"` (notice the blank space), this will make the interpreter treat it as a command, which leads to "command not found"

The next thing is to use "until" loop, this will make sure that all processes has started and got it's PID before renice them.

Also, since this script is very basic, I decided to change it to sh to make it portable. This makes the hack runs on postmarketOS without additional packages.

Tested and working on Arch Linux ARM for PinePhone.